### PR TITLE
ASE: Use `guess=true` while checking parser support

### DIFF
--- a/lib/AtomsIOPython/Project.toml
+++ b/lib/AtomsIOPython/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomsIOPython"
 uuid = "9e4c859b-2281-48ef-8059-f50fe53c37b0"
 authors = ["Michael F. Herbst <info@michael-herbst.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 ASEconvert = "3da9722f-58c2-4165-81be-b4d7253e8fd2"

--- a/lib/AtomsIOPython/src/ase.jl
+++ b/lib/AtomsIOPython/src/ase.jl
@@ -18,6 +18,15 @@ end
 
 function AtomsIO.supports_parsing(parser::AseParser, file; save, trajectory)
     format = ""
+
+    if !save && !parser.guess
+        @warn("There is a bug in ASE (as of 08/11/2023, ASE 3.22), which gets triggered "
+              "when trying to save files with `AseParser(; guess=false)`. This could mean "
+              "that AtomsIO falsely reports a file as unsupported even though it is indeed "
+              "supported for writing in ASe. In this case use `AseParser(; guess=true)` and"
+              "try again.")
+    end
+
     try
         # read=true causes ASE to open the file, read a few bytes and check for magic bytes
         format = ase.io.formats.filetype(file; read=!save, guess=parser.guess)

--- a/lib/AtomsIOPython/src/ase.jl
+++ b/lib/AtomsIOPython/src/ase.jl
@@ -17,7 +17,7 @@ struct AseParser <: AbstractParser end
 function AtomsIO.supports_parsing(::AseParser, file; save, trajectory)
     format = ""
     try
-        format = ase.io.formats.filetype(file; read=!save, guess=false)
+        format = ase.io.formats.filetype(file; read=!save, guess=true)
     catch e
         e isa PyException && return false
         rethrow()

--- a/lib/AtomsIOPython/src/ase.jl
+++ b/lib/AtomsIOPython/src/ase.jl
@@ -11,7 +11,7 @@ Supported formats:
   - ASE trajectory files
   - [XYZ](https://openbabel.org/wiki/XYZ) and [extxyz](https://github.com/libAtoms/extxyz#extended-xyz-specification-and-parsing-tools) files
 """
-Base.@kwdef struct AseParser <: AbstractParser 
+Base.@kwdef struct AseParser <: AbstractParser
     guess::Bool = true
 end
 

--- a/lib/AtomsIOPython/src/ase.jl
+++ b/lib/AtomsIOPython/src/ase.jl
@@ -32,15 +32,15 @@ function AtomsIO.supports_parsing(parser::AseParser, file; save, trajectory)
 
     ioformat = ase.io.formats.ioformats[format]
     supports_trajectory = '+' in ioformat.code
-
-    if (
-        (save && pyconvert(Bool, ioformat.can_write)) || # Check whether ASE can write format
-        (!save && pyconvert(Bool, ioformat.can_read)) # Check whether ASE can read format
-       )
-        return (trajectory ? supports_trajectory : true)
+    if save && !pyconvert(Bool, ioformat.can_write)
+        return false  # Want to write, but ASE cannot write
+    elseif !save && !pyconvert(Bool, ioformat.can_read)
+        return false  # Want to read, but ASE cannot read
+    elseif trajectory && !supports_trajectory
+        return false  # Trajectory operations, but not supported by ASE
     end
 
-    return false
+    true # We got here, so all is good
 end
 
 function AtomsIO.load_system(::AseParser, file::AbstractString, index=nothing;

--- a/lib/AtomsIOPython/src/ase.jl
+++ b/lib/AtomsIOPython/src/ase.jl
@@ -21,9 +21,9 @@ function AtomsIO.supports_parsing(parser::AseParser, file; save, trajectory)
 
     if !save && !parser.guess
         @warn("There is a bug in ASE (as of 08/11/2023, ASE 3.22), which gets triggered " *
-              "when trying to save files with `AseParser(; guess=false)`. This could mean " *
+              "when trying to read files with `AseParser(; guess=false)`. This could mean " *
               "that AtomsIO falsely reports a file as unsupported even though it is indeed " *
-              "supported for writing in ASe. In this case use `AseParser(; guess=true)` and" *
+              "supported for reading with ASE. In this case use `AseParser(; guess=true)` and" *
               "try again.")
     end
 

--- a/lib/AtomsIOPython/src/ase.jl
+++ b/lib/AtomsIOPython/src/ase.jl
@@ -12,7 +12,6 @@ Supported formats:
   - [XYZ](https://openbabel.org/wiki/XYZ) and [extxyz](https://github.com/libAtoms/extxyz#extended-xyz-specification-and-parsing-tools) files
 """
 @kwdef struct AseParser <: AbstractParser 
-    read::Bool = true
     guess::Bool = true
 end
 
@@ -20,7 +19,8 @@ end
 function AtomsIO.supports_parsing(parser::AseParser, file; save, trajectory)
     format = ""
     try
-        format = ase.io.formats.filetype(file; read=parser.read, guess=parser.guess)
+        # read=true causes ASE to open the file, read a few bytes and check for magic bytes
+        format = ase.io.formats.filetype(file; read=!save, guess=parser.guess)
     catch e
         e isa PyException && return false
         rethrow()

--- a/lib/AtomsIOPython/src/ase.jl
+++ b/lib/AtomsIOPython/src/ase.jl
@@ -20,10 +20,10 @@ function AtomsIO.supports_parsing(parser::AseParser, file; save, trajectory)
     format = ""
 
     if !save && !parser.guess
-        @warn("There is a bug in ASE (as of 08/11/2023, ASE 3.22), which gets triggered "
-              "when trying to save files with `AseParser(; guess=false)`. This could mean "
-              "that AtomsIO falsely reports a file as unsupported even though it is indeed "
-              "supported for writing in ASe. In this case use `AseParser(; guess=true)` and"
+        @warn("There is a bug in ASE (as of 08/11/2023, ASE 3.22), which gets triggered " *
+              "when trying to save files with `AseParser(; guess=false)`. This could mean " *
+              "that AtomsIO falsely reports a file as unsupported even though it is indeed " *
+              "supported for writing in ASe. In this case use `AseParser(; guess=true)` and" *
               "try again.")
     end
 

--- a/lib/AtomsIOPython/src/ase.jl
+++ b/lib/AtomsIOPython/src/ase.jl
@@ -31,29 +31,16 @@ function AtomsIO.supports_parsing(parser::AseParser, file; save, trajectory)
     end
 
     ioformat = ase.io.formats.ioformats[format]
-    supports_trajectory = '+' in ase.io.formats.ioformats[format].code
+    supports_trajectory = '+' in ioformat.code
 
-    if save # Check whether ASE can write format
-        if Bool(ioformat.can_write)
-            if trajectory
-                return supports_trajectory
-            else
-                return true
-            end
-        else
-            return false
-        end
-    else # Check whether ASE can read format
-        if Bool(ioformat.can_read)
-            if trajectory
-                return supports_trajectory
-            else
-                return true
-            end
-        else
-            return false
-        end
+    if (
+        (save && pyconvert(Bool, ioformat.can_write)) || # Check whether ASE can write format
+        (!save && pyconvert(Bool, ioformat.can_read)) # Check whether ASE can read format
+       )
+        return (trajectory ? supports_trajectory : true)
     end
+
+    return false
 end
 
 function AtomsIO.load_system(::AseParser, file::AbstractString, index=nothing;

--- a/lib/AtomsIOPython/src/ase.jl
+++ b/lib/AtomsIOPython/src/ase.jl
@@ -11,7 +11,7 @@ Supported formats:
   - ASE trajectory files
   - [XYZ](https://openbabel.org/wiki/XYZ) and [extxyz](https://github.com/libAtoms/extxyz#extended-xyz-specification-and-parsing-tools) files
 """
-@kwdef struct AseParser <: AbstractParser 
+Base.@kwdef struct AseParser <: AbstractParser 
     guess::Bool = true
 end
 

--- a/lib/AtomsIOPython/test/ase.jl
+++ b/lib/AtomsIOPython/test/ase.jl
@@ -80,7 +80,7 @@ end
         @test  supports_parsing(AseParser(), prefix * ".xsf";  save=false, trajectory=true )
 
         @test_warn "There is a bug in ASE" begin
-            supports_parsing(AseParser(; guess=false), prefix * ".pwi"; save=true, trajectory=false)
+            supports_parsing(AseParser(; guess=false), prefix * ".pwi"; save=false, trajectory=false)
         end
     end
 end

--- a/lib/AtomsIOPython/test/ase.jl
+++ b/lib/AtomsIOPython/test/ase.jl
@@ -78,5 +78,9 @@ end
         @test  supports_parsing(AseParser(), prefix * ".traj"; save=false, trajectory=true )
         @test  supports_parsing(AseParser(), prefix * ".xsf";  save=false, trajectory=false)
         @test  supports_parsing(AseParser(), prefix * ".xsf";  save=false, trajectory=true )
+
+        @test_warn "There is a bug in ASE" begin
+            supports_parsing(AseParser(; guess=false), prefix * ".pwi"; save=true, trajectory=false)
+        end
     end
 end

--- a/lib/AtomsIOPython/test/ase.jl
+++ b/lib/AtomsIOPython/test/ase.jl
@@ -79,7 +79,7 @@ end
         @test  supports_parsing(AseParser(), prefix * ".xsf";  save=false, trajectory=false)
         @test  supports_parsing(AseParser(), prefix * ".xsf";  save=false, trajectory=true )
 
-        @test_warn "There is a bug in ASE" begin
+        @test_logs (:warn, ) begin
             supports_parsing(AseParser(; guess=false), prefix * ".pwi"; save=false, trajectory=false)
         end
     end

--- a/lib/AtomsIOPython/test/ase.jl
+++ b/lib/AtomsIOPython/test/ase.jl
@@ -63,10 +63,14 @@ end
         @test  supports_parsing(AseParser(), prefix * ".cif";  save=true,  trajectory=true )
         @test  supports_parsing(AseParser(), prefix * ".traj"; save=true,  trajectory=false)
         @test  supports_parsing(AseParser(), prefix * ".traj"; save=true,  trajectory=true )
+        @test  supports_parsing(AseParser(), prefix * ".xyz";  save=true,  trajectory=false)
+        @test  supports_parsing(AseParser(), prefix * ".xyz";  save=true,  trajectory=true )
         @test  supports_parsing(AseParser(), prefix * ".xsf";  save=true,  trajectory=false)
         @test  supports_parsing(AseParser(), prefix * ".xsf";  save=true,  trajectory=true )
+        @test  supports_parsing(AseParser(), prefix * ".vasp"; save=true,  trajectory=false)
+        @test !supports_parsing(AseParser(), prefix * ".vasp"; save=true,  trajectory=true )
 
-        for ext in (".pwi", ".cif", ".traj", ".xsf")
+        for ext in (".pwi", ".cif", ".traj", ".xyz", ".xsf", ".vasp")
             save_system(AseParser(), prefix * ext, make_ase_system().system)
         end
 
@@ -76,8 +80,12 @@ end
         @test  supports_parsing(AseParser(), prefix * ".cif";  save=false, trajectory=true )
         @test  supports_parsing(AseParser(), prefix * ".traj"; save=false, trajectory=false)
         @test  supports_parsing(AseParser(), prefix * ".traj"; save=false, trajectory=true )
+        @test  supports_parsing(AseParser(), prefix * ".xyz";  save=false, trajectory=false)
+        @test  supports_parsing(AseParser(), prefix * ".xyz";  save=false, trajectory=true )
         @test  supports_parsing(AseParser(), prefix * ".xsf";  save=false, trajectory=false)
         @test  supports_parsing(AseParser(), prefix * ".xsf";  save=false, trajectory=true )
+        @test  supports_parsing(AseParser(), prefix * ".vasp"; save=false, trajectory=false)
+        @test !supports_parsing(AseParser(), prefix * ".vasp"; save=false, trajectory=true )
 
         @test_logs (:warn, ) begin
             supports_parsing(AseParser(; guess=false), prefix * ".pwi"; save=false, trajectory=false)

--- a/lib/AtomsIOPython/test/ase.jl
+++ b/lib/AtomsIOPython/test/ase.jl
@@ -63,8 +63,10 @@ end
         @test  supports_parsing(AseParser(), prefix * ".cif";  save=true,  trajectory=true )
         @test  supports_parsing(AseParser(), prefix * ".traj"; save=true,  trajectory=false)
         @test  supports_parsing(AseParser(), prefix * ".traj"; save=true,  trajectory=true )
+        @test  supports_parsing(AseParser(), prefix * ".xsf";  save=true,  trajectory=false)
+        @test  supports_parsing(AseParser(), prefix * ".xsf";  save=true,  trajectory=true )
 
-        for ext in (".pwi", ".cif", ".traj")
+        for ext in (".pwi", ".cif", ".traj", ".xsf")
             save_system(AseParser(), prefix * ext, make_ase_system().system)
         end
 
@@ -74,5 +76,7 @@ end
         @test  supports_parsing(AseParser(), prefix * ".cif";  save=false, trajectory=true )
         @test  supports_parsing(AseParser(), prefix * ".traj"; save=false, trajectory=false)
         @test  supports_parsing(AseParser(), prefix * ".traj"; save=false, trajectory=true )
+        @test  supports_parsing(AseParser(), prefix * ".xsf";  save=false, trajectory=false)
+        @test  supports_parsing(AseParser(), prefix * ".xsf";  save=false, trajectory=true )
     end
 end


### PR DESCRIPTION
Is there a reason for setting `guess=false` while checking parser support? Only if `guess=true` will ASE guess the extension based on extension and therefore can read many formats like VASP POSCARS (\*.vasp, POSCAR\*), QE input (\*.in) etc. Currently, it shows an error: `Python: UnknownFileTypeError: Could not guess file type` due to setting `guess=false`.