### PR TITLE
Re-enable XSF support with XCrySDenStructureFormat.jl v0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomsIO"
 uuid = "1692102d-eeb4-4df9-807b-c9517f998d44"
-authors = ["Michael F. Herbst <info@michael-herbst.com> and contributors"]
 version = "0.3.0"
+authors = ["Michael F. Herbst <info@michael-herbst.com> and contributors"]
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
@@ -12,6 +12,7 @@ PeriodicTable = "7b2266bf-644c-5ea3-82d8-af4bbd25a884"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
+XCrySDenStructureFormat = "02310045-4665-40c9-a658-98c497d2eca9"
 
 [compat]
 AtomsBase = "0.5"
@@ -22,6 +23,7 @@ PeriodicTable = "1"
 Reexport = "1"
 Unitful = "1"
 UnitfulAtomic = "1"
+XCrySDenStructureFormat = "0.2"
 julia = "1.9"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AtomsIO"
 uuid = "1692102d-eeb4-4df9-807b-c9517f998d44"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Michael F. Herbst <info@michael-herbst.com> and contributors"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ AtomsIO currently integrates with
   - [ExtXYZ](https://github.com/libAtoms/ExtXYZ.jl)
   - [ASEconvert](https://github.com/mfherbst/ASEconvert.jl)
     (respectively [ASE](https://ase-lib.org))
+  - [XCrySDenStructureFormat](https://github.com/azadoks/XCrySDenStructureFormat.jl)
 
 and supports all file formats any of these packages support.
 Amongst others AtomsIO supports the following formats
@@ -26,5 +27,6 @@ Amongst others AtomsIO supports the following formats
   - [Quantum Espresso](https://www.quantum-espresso.org/Doc/INPUT_PW.html) / [ABINIT](https://docs.abinit.org/variables/) / [VASP](https://www.vasp.at/wiki/) input files
   - ASE / [Gromacs](http://manual.gromacs.org/archive/5.0.7/online/trj.html) / [LAMMPS](https://lammps.sandia.gov/doc/dump.html) / [Amber](http://ambermd.org/netcdf/nctraj.xhtml) trajectory files
   - [XYZ](https://openbabel.org/wiki/XYZ) and [extxyz](https://github.com/libAtoms/extxyz#extended-xyz-specification-and-parsing-tools) files
+  - [XSF](http://www.xcrysden.org/doc/XSF.html) (XCrySDen) structure and trajectory files
 
 For more details see the [documentation](https://mfherbst.github.io/AtomsIO.jl/stable).

--- a/README.md
+++ b/README.md
@@ -28,16 +28,3 @@ Amongst others AtomsIO supports the following formats
   - [XYZ](https://openbabel.org/wiki/XYZ) and [extxyz](https://github.com/libAtoms/extxyz#extended-xyz-specification-and-parsing-tools) files
 
 For more details see the [documentation](https://mfherbst.github.io/AtomsIO.jl/stable).
-
-## File formats supported in earlier versions
-These file formats were supported in earlier versions of AtomsIO, but are now
-dropped as the implementing packages lack a maintainer and no longer function
-with the most recent version of AtomsBase.
-
-  - [XSF](http://www.xcrysden.org/doc/XSF.html) (XCrySDen) structure and
-    trajectory files were supported using the
-    [XCrySDenStructureFormat](https://github.com/azadoks/XCrySDenStructureFormat.jl)
-    package.
-    In case of interest,
-    see the [draft PR](https://github.com/azadoks/XCrySDenStructureFormat.jl/pull/6),
-    which can be completed to re-enable support.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -25,18 +25,6 @@ For more details see [Saving and loading files](@ref) and [File Formats](@ref).
     package `AtomsIOPython` needs to be loaded to make these parsers available.
     See [File Formats](@ref) for more details.
 
-!!! note "Formats supported in earlier versions of AtomsIO"
-    These file formats were supported in earlier versions of AtomsIO, but are now
-    dropped as the implementing packages lack a maintainer and no longer function
-    with the most recent version of AtomsBase.
-      - [XSF](http://www.xcrysden.org/doc/XSF.html) (XCrySDen) structure and
-        trajectory files were supported using the
-        [XCrySDenStructureFormat](https://github.com/azadoks/XCrySDenStructureFormat.jl)
-        package.
-        In case of interest,
-        see the [draft PR](https://github.com/azadoks/XCrySDenStructureFormat.jl/pull/6),
-        which can be completed to re-enable support.
-
 ## Usage example
 
 ```julia

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,6 +8,7 @@ AtomsIO currently integrates with
   - [ExtXYZ](https://github.com/libAtoms/ExtXYZ.jl)
   - [ASEconvert](https://github.com/mfherbst/ASEconvert.jl)
     (respectively [ASE](https://ase-lib.org))
+  - [XCrySDenStructureFormat](https://github.com/azadoks/XCrySDenStructureFormat.jl)
 
 and supports all file formats any of these packages support
 (see their respective documentation). This includes
@@ -16,6 +17,7 @@ and supports all file formats any of these packages support
   - [Quantum Espresso](https://www.quantum-espresso.org/Doc/INPUT_PW.html) / [ABINIT](https://docs.abinit.org/variables/) / [VASP](https://www.vasp.at/wiki/) input files
   - ASE / [Gromacs](http://manual.gromacs.org/archive/5.0.7/online/trj.html) / [LAMMPS](https://lammps.sandia.gov/doc/dump.html) / [Amber](http://ambermd.org/netcdf/nctraj.xhtml) trajectory files
   - [XYZ](https://openbabel.org/wiki/XYZ) and [extxyz](https://github.com/libAtoms/extxyz#extended-xyz-specification-and-parsing-tools) files
+  - [XSF](http://www.xcrysden.org/doc/XSF.html) (XCrySDen) structure and trajectory files
 
 For more details see [Saving and loading files](@ref) and [File Formats](@ref).
 

--- a/src/xsf.jl
+++ b/src/xsf.jl
@@ -1,4 +1,4 @@
-# import XCrySDenStructureFormat as XSF
+import XCrySDenStructureFormat as XSF
 
 """
 Parse or write file using [XCrySDenStructureFormat](https://github.com/azadoks/XCrySDenStructureFormat.jl).
@@ -7,15 +7,6 @@ Supported formats:
   - [XSF](http://www.xcrysden.org/doc/XSF.html) and [AXSF](http://www.xcrysden.org/doc/XSF.html)
     atomic structure files. These are the files typically used by the
     [XCrySDen](http://www.xcrysden.org/) visualisation program.
-
-!!! note "Format has been dropped in AtomsIO 0.3"
-    This file format has been supported in earlier versions of AtomsIO, but is now
-    dropped as the implementing packages lack a maintainer and no longer function
-    with the most recent version of AtomsBase.
-    In case of interest,
-    see the [draft PR](https://github.com/azadoks/XCrySDenStructureFormat.jl/pull/6),
-    which can be completed to re-enable support.
-
 """
 struct XcrysdenstructureformatParser <: AbstractParser end
 
@@ -24,38 +15,28 @@ function supports_parsing(::XcrysdenstructureformatParser, file; save, trajector
     ext in (".xsf", ".axsf")
 end
 
-function _xsf_error_out()
-    error("Format has been dropped due to a lack of a maintainer for the " *
-          "implementing package. See help of XcrysdenstructureformatParser struct " *
-          "for details.")
-end
-
 function load_system(::XcrysdenstructureformatParser, file::AbstractString, index=nothing)
-    _xsf_error_out()
-    # frames = XSF.load_xsf(file)
-    # isempty(frames) && error(
-    #     "XSF returned no frames. Check the passed file is a valid (a)xsf file."
-    # )
-    # if isnothing(index)
-    #     return last(frames)
-    # else
-    #     return frames[index]
-    # end
+    frames = XSF.load_xsf(file)
+    isempty(frames) && error(
+        "XSF returned no frames. Check the passed file is a valid (a)xsf file."
+    )
+    if isnothing(index)
+        return last(frames)
+    else
+        return frames[index]
+    end
 end
 
 function save_system(::XcrysdenstructureformatParser,
                      file::AbstractString, system::AbstractSystem)
-    _xsf_error_out()
-    # XSF.save_xsf(file, system)
+    XSF.save_xsf(file, system)
 end
 
 function load_trajectory(::XcrysdenstructureformatParser, file::AbstractString)
-    _xsf_error_out()
-    # XSF.load_xsf(file)
+    XSF.load_xsf(file)
 end
 
 function save_trajectory(::XcrysdenstructureformatParser, file::AbstractString,
                          systems::AbstractVector{<:AbstractSystem})
-    _xsf_error_out()
-    # XSF.save_xsf(file, systems)
+    XSF.save_xsf(file, systems)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ if GROUP == "Core"
         include("safe_load.jl")
         include("chemfiles.jl")
         include("extxyz.jl")
-        # include("xsf.jl")  # XCrySDenStructureFormat looking for a new maintainer
+        include("xsf.jl")
         include("failed_files.jl")
         # For the comparison tests (also between Chemfiles and ExtXYZ and other
         # non-python libraries) see the AtomsIOPython subproject

--- a/test/xsf.jl
+++ b/test/xsf.jl
@@ -4,10 +4,6 @@ using AtomsBaseTesting
 using Unitful
 using UnitfulAtomic
 
-# TODO Note that this test is currently not included in runtests.jl
-#      since https://github.com/azadoks/XCrySDenStructureFormat.jl is looking
-#      for a new maintainer.
-
 function make_xsf_system(D=3; drop_atprop=Symbol[], drop_sysprop=Symbol[], kwargs...)
     @assert D == 3  # Only 3D systems are supported
     n_atoms = 5     # Copied from AtomsBaseTesting.make_test_system, used for making forces


### PR DESCRIPTION
Seems to pass the test suite locally; let's see how it goes here.